### PR TITLE
remove blue outline from (native) dialog

### DIFF
--- a/src/fds-dialog.ts
+++ b/src/fds-dialog.ts
@@ -45,6 +45,7 @@ export default class FdsDialog extends LitElement {
       box-shadow: ${tokenVar(FdsStyleElevation400)};
       padding: calc(${tokenVar(FdsRadiusLarge)} / 2);
       overflow: visible;
+      outline: none;
     }
   `
 }


### PR DESCRIPTION
Häiritsee ainakin omaa silmää, kun dialogia avattaessa siihen tulee luonnollinen focus, ja focuksen mukana selkeät siniset reunat, tosin en tiedä pitäisikö saavutettavuusmielessä jättää piilottamatta.