### PR TITLE
fds-dialog: Add outside-modal-click event

### DIFF
--- a/src/fds-dialog.ts
+++ b/src/fds-dialog.ts
@@ -8,6 +8,8 @@ import { FdsRadiusLarge, FdsStyleElevation400 } from '@fintraffic-design/coreui-
 /**
  * Dialog component.
  *
+ * @event outside-modal-click - Dispatches a custom event when the dialog is a modal dialog and user clicks outside of it.
+ *
  * @property {boolean} modal
  * Dialog is a modal dialog: Does not allow interaction with background elements.
  */
@@ -17,6 +19,16 @@ export default class FdsDialog extends LitElement {
 
   @query('dialog')
   private readonly dialog: HTMLDialogElement | undefined
+
+  constructor() {
+    super()
+
+    this.addEventListener('click', ({ target }) => {
+      if (this.modal && target === this) {
+        this.dispatchEvent(new CustomEvent('outside-modal-click'))
+      }
+    })
+  }
 
   override updated(changes: PropertyValues<FdsDialog>): void {
     super.updated(changes)

--- a/src/stories/fds-dialog.stories.ts
+++ b/src/stories/fds-dialog.stories.ts
@@ -18,9 +18,13 @@ export default {
           Selector: `<fds-dialog>`",
       },
     },
+    actions: {
+      handles: ['outside-modal-click'],
+    },
   },
   args: {
     modal: false,
+    outsideModalClick: undefined,
     slot: undefined,
   },
   argTypes: {
@@ -32,6 +36,14 @@ export default {
         category: 'Properties',
         defaultValue: { summary: 'false' },
       },
+    },
+    outsideModalClick: {
+      description:
+        'Event that is dispatched when the dialog is a modal dialog and user clicks outside of it. <br><br> \
+      `CustomEvent<void>`',
+      table: { category: 'Events' },
+      name: '@outside-modal-click',
+      control: false,
     },
     slot: {
       description: 'Default slot. Container for the dialog content.',
@@ -56,7 +68,11 @@ const Template: StoryFn = ({ modal }) => {
     </style>
 
     <div style="height: 260px;">
-      <fds-dialog .modal=${modal} style="width: 50%; min-width: 30rem; max-width: 40rem">
+      <fds-dialog
+        .modal=${modal}
+        @outside-modal-click=${(): void => console.log('@outside-modal-click')}
+        style="width: 50%; min-width: 30rem; max-width: 40rem"
+      >
         <fds-card .elevation="${FdsCardElevation.none}">
           <h4 slot="header-title">Modal title</h4>
           <p>Modal message</p>


### PR DESCRIPTION
Tämä mahdollistaa pääasiassa dialogin sulkemisen jos käyttäjä klikkaa modaalidialogin ulkopuolelta.