### PR TITLE
fds-dialog: Prevent updating dialog when modal has not changed

### DIFF
--- a/src/fds-dialog.ts
+++ b/src/fds-dialog.ts
@@ -42,7 +42,7 @@ export default class FdsDialog extends LitElement {
 
   override updated(changes: PropertyValues<FdsDialog>): void {
     super.updated(changes)
-    if (this.modal !== changes.get('modal')) {
+    if (changes.has('modal') && this.modal !== changes.get('modal')) {
       this.dialog?.close()
       if (this.modal) {
         this.dialog?.showModal()


### PR DESCRIPTION
Since `fds-dialog` has more than one property now (see https://github.com/fintraffic-design/coreui-components/pull/37), a check needs to be added to the `updated` method to only close and show the dialog again if the `modal` property changes.