### PR TITLE
fix: options-list visibility issue

### DIFF
--- a/src/combobox.ts
+++ b/src/combobox.ts
@@ -287,6 +287,7 @@ export class FdsCombobox extends LitElement {
         cursor: pointer;
         display: block;
         position: absolute;
+        z-index: 1;
         overflow-y: scroll;
 
         min-width: 100%;

--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -188,6 +188,7 @@ export class FdsDropdown<T> extends LitElement {
         cursor: pointer;
         display: block;
         position: absolute;
+        z-index: 1;
         overflow-y: scroll;
 
         min-width: 100%;


### PR DESCRIPTION
Add `z-index` of 1 to options-list so it doesn't render behind other components (affects dropdown and combobox).

Fixes #66