### PR TITLE
fix: use full height in card content

### DIFF
--- a/src/card.ts
+++ b/src/card.ts
@@ -84,6 +84,7 @@ export class FdsCard extends LitElement {
       }
 
       .card__content {
+        height: 100%;
         padding: ${FdsSize2} ${FdsSize4};
       }
     `,


### PR DESCRIPTION
Tuli aluetyökalussa tällainen tarve:
![image](https://github.com/user-attachments/assets/b5345b7c-d2df-4773-9066-63910d8ee5b2)

Eli pitäisi saada ilmaa tuohon tekstien ja nappulan väliin, joka määrittyy automaattisesti saman rivin korkeimman elementin mukaan. Mikäli tuolla card__content slotilla ei ole height 100%, en saa tätä millään toimimaan, koska tuo lapsi elementti joka on slotattuna sinne sisään ei pysty kasvamaan:
![image](https://github.com/user-attachments/assets/bc7872c3-e889-4c86-b4f1-05f1fe04b5e0)

Tätä design systeemiähän oltiin kai kuoppaamassa, mutta tämä nyt jokatapauksessa olisi tässä kohtaa helpoin keino hoitaa tämä.