### PR TITLE
chore(deps): bump lucide from 0.265.0 to 0.473.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@fintraffic/fds-coreui-css": "^0.1.0",
         "@popperjs/core": "^2.11.8",
         "lit": "^2.8.0",
-        "lucide": "^0.265.0"
+        "lucide": "^0.473.0"
       },
       "devDependencies": {
         "@babel/core": "^7.23.3",
@@ -11518,9 +11518,9 @@
       }
     },
     "node_modules/lucide": {
-      "version": "0.265.0",
-      "resolved": "https://registry.npmjs.org/lucide/-/lucide-0.265.0.tgz",
-      "integrity": "sha512-UftGwLDfBwI4lKz2XjcyGQZrDObx3GNlqLO9s22T8+MhdvJEqJnNRErpOdL/6K6Z1i/iO1PeD4q4kqDXVhL5jw=="
+      "version": "0.473.0",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-0.473.0.tgz",
+      "integrity": "sha512-UIUNzfoXpYQQKiQO1M0bOOwv1BJt8EYSSFJt2HsVv39nd97lvA5H80Z+pmmeiW0cheUmWNpvh5w4JI0eZypd4Q=="
     },
     "node_modules/magic-string": {
       "version": "0.30.5",
@@ -24735,9 +24735,9 @@
       }
     },
     "lucide": {
-      "version": "0.265.0",
-      "resolved": "https://registry.npmjs.org/lucide/-/lucide-0.265.0.tgz",
-      "integrity": "sha512-UftGwLDfBwI4lKz2XjcyGQZrDObx3GNlqLO9s22T8+MhdvJEqJnNRErpOdL/6K6Z1i/iO1PeD4q4kqDXVhL5jw=="
+      "version": "0.473.0",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-0.473.0.tgz",
+      "integrity": "sha512-UIUNzfoXpYQQKiQO1M0bOOwv1BJt8EYSSFJt2HsVv39nd97lvA5H80Z+pmmeiW0cheUmWNpvh5w4JI0eZypd4Q=="
     },
     "magic-string": {
       "version": "0.30.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@fintraffic/fds-coreui-css": "^0.1.0",
     "@popperjs/core": "^2.11.8",
     "lit": "^2.8.0",
-    "lucide": "^0.265.0"
+    "lucide": "^0.473.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.3",


### PR DESCRIPTION
Tarvitsi päivittää tämä kirjasto tätä varten: https://github.com/fintraffic-design/fds-coreui-components/pull/74