### PR TITLE
fix: calculate dropdown menu max height

### DIFF
--- a/src/dropdown.ts
+++ b/src/dropdown.ts
@@ -63,6 +63,8 @@ export class FdsDropdown<T> extends LitElement {
 
   override firstUpdated(): void {
     this.tabIndex = 0
+    const rect = this.getBoundingClientRect()
+    this.style.setProperty('--dropdown-offset', `${rect.top + rect.height}px`)
   }
 
   override render(): TemplateResult {
@@ -193,8 +195,7 @@ export class FdsDropdown<T> extends LitElement {
 
         min-width: 100%;
         max-width: fit-content;
-        /* TODO: what value? */
-        max-height: 80vw;
+        max-height: calc(100vh - var(--dropdown-offset));
 
         box-shadow: ${FdsStyleElevation200};
       }


### PR DESCRIPTION
Dropdown-komponentin alasvetovalikossa oli tällainen kiusallinen bugi, että valikko valui viewportin ali, mikäli siinä oli vain tarpeeksi esineitä. Syy nyt oli aika selvä, tuohon oli vain laitettu alasvetolaatikko elementille max-height: 80vh. Uudessa ratkaisussa tuo maksimi korkeus lasketaan parent komponentin perusteella. Tämä ei ole vieläkään mikään täydellinen ratkaisu, sillä tuo laskenta tehdään vain kerran komponentin elinkaaren aikana.

Vanha:
![image](https://github.com/user-attachments/assets/6f52d974-a23d-472a-b073-af7177a6d5a8)

Uusi:
![image](https://github.com/user-attachments/assets/f0d0ec48-f461-41b6-a81d-463d261dda9d)
