### PR TITLE
chore(actions): update upload-pages-artifact action from v1 -> v3

### DIFF
--- a/.github/workflows/storybook-cd.yml
+++ b/.github/workflows/storybook-cd.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build Storybook
         run: npm run build-storybook
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./storybook-static
 


### PR DESCRIPTION
Huomasin että CD-putki oli hajonnut kun github on näemmä deprekoinut tuon vanhan version tuosta actionista:
https://github.com/fintraffic-design/fds-coreui-components/actions/runs/13746429374

Meillä kun ei tässä ole sen ihmeempiä parametreja käytetty, niin luultavasti toimii ilman muita muutoksia, ainakin perus use-case näytti [dokumentaatiossa](https://github.com/actions/upload-pages-artifact?tab=readme-ov-file#usage) samalta kun katoin.